### PR TITLE
Add private bridges to pots

### DIFF
--- a/create-runner.sh
+++ b/create-runner.sh
@@ -11,7 +11,11 @@ fi
 mkdir -p ${RUNNER_CONFIG_DIRECTORY}
 cd ${RUNNER_CONFIG_DIRECTORY}
 
-pot create -p ${POTNAME} -b ${FREEBSD_VERSION} -t single -f github-act ${EXTRA_FLAVOURS} -f github-act-configured
+pot create -p ${POTNAME} -b ${FREEBSD_VERSION} -t single \
+	-f github-act ${EXTRA_FLAVOURS} -f github-act-configured \
+	-N private-bridge -B bridge-${FREEBSD_VERSION} -i auto -S ipv4
+
+potnet etc-hosts -b bridge-${FREEBSD_VERSION} >> /etc/hosts
 
 echo
 echo Created pot:

--- a/create-runner.sh
+++ b/create-runner.sh
@@ -11,9 +11,27 @@ fi
 mkdir -p ${RUNNER_CONFIG_DIRECTORY}
 cd ${RUNNER_CONFIG_DIRECTORY}
 
-pot create -p ${POTNAME} -b ${FREEBSD_VERSION} -t single \
-	-f github-act ${EXTRA_FLAVOURS} -f github-act-configured \
-	-N private-bridge -B bridge-${FREEBSD_VERSION} -i auto -S ipv4
+if [ ${POT_MOUNT_BASE} ]; then
+    SIBLING_DIR=${POT_MOUNT_BASE}/jails/sibling
+else
+    SIBLING_DIR=/opt/pot/jails/sibling
+fi
+
+BRIDGE_NAME="bridge-${FREEBSD_VERSION}"
+if [ ! $(pot ls -B | grep -Eo $BRIDGE_NAME) ]; then
+    pot create-private-bridge -B $BRIDGE_NAME -S 64
+    pot vnet-start -B $BRIDGE_NAME
+fi
+
+if [ ! -d $SIBLING_DIR ]; then
+    pot create -p sibling -b ${FREEBSD_VERSION} -t single -f bootstrap \
+        -N private-bridge -B $BRIDGE_NAME -i auto -S ipv4
+    pot snap -p sibling
+fi
+
+pot clone -p ${POTNAME} -P sibling -f github-act ${EXTRA_FLAVOURS} \
+    -f github-act-configured -N private-bridge -B $BRIDGE_NAME \
+    -i auto -S ipv4
 
 potnet etc-hosts -b bridge-${FREEBSD_VERSION} >> /etc/hosts
 


### PR DESCRIPTION
This PR ensures that pots have their own IP via private bridge.

It might be necessary to purge deprecated entries from `/etc/hosts` in due course, possibly via a cronjob or similar.