### PR TITLE
Patch ephemeral pots to bootstrap pkg on CheriBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ To install under CheriBSD 23.11, for instance:
 POT_MOUNT_BASE=/opt/pot FREEBSD_VERSION=23.11 ./install.sh
 ```
 
+To initialise a runner via GitHub:
+```shell
+POT_MOUNT_BASE=/opt/pot/ \
+FREEBSD_VERSION=23.11 \
+RUNNER_NAME=self-hosted \
+./config.sh --url YOUR_REPOSITORY_URL --token YOUR_TOKEN
+```
+
+To configure healthchecks via `crontab -e`, add the following in your editor of choice:
+```
+* 9 */1 * * /sbin/zpool status -v
+* 12 */1 * * /etc/cron.d/scrub-pool.sh
+* */1 * * * /etc/cron.d/clean-pots.sh
+*/1 * * * * /etc/cron.d/restart-actions.sh
+```
+
 
 Wrapper scripts to run GitHub actions in a jail on FreeBSD
 ----------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Go runtime on CheriBSD.
 It also copies the libraries for CheriBSD's various ABIs from the host
 to the release's base pot to ensure that `pkg64` and `pkg64cb` are
 useable on capability-aware systems like Morello.
+To install under CheriBSD 23.11, for instance:
+```shell
+POT_MOUNT_BASE=/opt/pot FREEBSD_VERSION=23.11 ./install.sh
+```
 
 
 Wrapper scripts to run GitHub actions in a jail on FreeBSD

--- a/check-envs.sh
+++ b/check-envs.sh
@@ -15,5 +15,4 @@ fi
 # FIXME: We shouldn't be allowing anything that isn't allowed in a path
 # component here either.
 POTNAME=$(echo ${RUNNER_NAME} | sed 's/\./_/g')
-BASENAME=base-$(echo $FREEBSD_VERSION | sed 's/\./_/g')
 RUNNER_CONFIG_DIRECTORY=`pwd`/runners/${POTNAME}

--- a/check-pots.sh
+++ b/check-pots.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 set -euo pipefail
 
 # Debug any running pots by performing a basic healthcheck

--- a/create-runner.sh
+++ b/create-runner.sh
@@ -11,7 +11,18 @@ fi
 mkdir -p ${RUNNER_CONFIG_DIRECTORY}
 cd ${RUNNER_CONFIG_DIRECTORY}
 
-pot create -p ${POTNAME} -b ${FREEBSD_VERSION} -t single -f github-act ${EXTRA_FLAVOURS} -f github-act-configured
+if [ ${POT_MOUNT_BASE} ]; then
+    SIBLING_DIR=${POT_MOUNT_BASE}/jails/sibling
+else
+    SIBLING_DIR=/opt/pot/jails/sibling
+fi
+
+if [ ! -d $SIBLING_DIR ]; then
+    pot create -p sibling -b ${FREEBSD_VERSION} -t single -f bootstrap
+    pot snap -p sibling
+fi
+
+pot clone -p ${POTNAME} -P sibling -f github-act ${EXTRA_FLAVOURS} -f github-act-configured
 
 echo
 echo Created pot:

--- a/flavours/bootstrap
+++ b/flavours/bootstrap
@@ -1,0 +1,2 @@
+copy-in -s /usr/lib64 -d /root/lib64
+copy-in -s /usr/lib64cb -d /root/lib64cb

--- a/flavours/github-act
+++ b/flavours/github-act
@@ -1,3 +1,6 @@
 copy-in -s github.conf -d /root/github-config
 set-attribute -A persistent -V NO
 set-attribute -A no-rc-script -V ON
+set-attribute -A no-tmpfs -V ON
+set-attribute -A nullfs -V ON
+set-attribute -A zfs -V ON

--- a/flavours/github-act-configure.sh
+++ b/flavours/github-act-configure.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 # Source the configuration file.
 . /root/github-config
 cat /root/github-config

--- a/flavours/github-act-copyout-config
+++ b/flavours/github-act-copyout-config
@@ -2,3 +2,6 @@ copy-in -s github.conf -d /root/github-config
 mount-in ${RUNNER_CONFIG_DIRECTORY}
 set-attribute -A persistent -V NO
 set-attribute -A no-rc-script -V ON
+set-attribute -A no-tmpfs -V ON
+set-attribute -A nullfs -V ON
+set-attribute -A zfs -V ON

--- a/flavours/github-act.sh
+++ b/flavours/github-act.sh
@@ -12,7 +12,21 @@ case $( . /etc/os-release; echo $NAME ) in
 esac
 
 # Install dependencies
-pkg64 ins -y git node bash
+cp -fR /root/lib64 /usr
+rm -R /root/lib64
+cp -fR /root/lib64cb /usr
+rm -R /root/lib64cb
+
+if [ $(which pkg64c) ]; then
+    for pkg in pkg64 pkg64c pkg64cb; do
+        $pkg -N || $pkg bootstrap -fy
+    done
+else
+    echo "[err] failed to find pkg64c"
+    exit
+fi
+
+pkg64 install -fy git node bash
 
 # Install the runner
 curl -LO https://github.com/ChristopherHX/github-act-runner/releases/download/v0.6.7/binary-freebsd-arm64.tar.gz

--- a/flavours/github-act.sh
+++ b/flavours/github-act.sh
@@ -15,8 +15,8 @@ esac
 pkg64 ins -y git node bash
 
 # Install the runner
-curl -LO https://github.com/ChristopherHX/github-act-runner/releases/download/v0.6.7/binary-freebsd-arm.tar.gz
-tar -xvf binary-freebsd-arm.tar.gz github-act-runner
+curl -LO https://github.com/ChristopherHX/github-act-runner/releases/download/v0.6.7/binary-freebsd-arm64.tar.gz
+tar -xvf binary-freebsd-arm64.tar.gz github-act-runner
 cp github-act-runner /usr/local64/bin/github-act-runner
 
 # Create the config directory

--- a/install.sh
+++ b/install.sh
@@ -7,10 +7,8 @@ if [ ! -d ${FLAVOURS} ]; then
 	exit 1
 fi
 
-BASENAME="base-"${FREEBSD_VERSION}
-BASEDIR="${POT_MOUNT_BASE}/bases/${BASENAME}/${FREEBSD_VERSION}"
-echo Creating base pot for ${FREEBSD_VERSION}
-if [ ! -e "${BASEDIR}" ]; then
+if [ ! $(pot ls -b | grep -Eo ${FREEBSD_VERSION}) ]; then
+	echo Creating base pot for ${FREEBSD_VERSION}
 	mkdir -p /usr/local/share/freebsd/MANIFESTS/
 	ARCH=$(curl -s \
 		https://download.cheribsd.org/releases/arm64/aarch64c/ | \
@@ -22,22 +20,10 @@ if [ ! -e "${BASEDIR}" ]; then
 
 	pot create-base -r $FREEBSD_VERSION
 
-	echo Adding libraries to the $BASENAME pot
-	for DIR in lib64 lib64cb; do
-		cp -r /usr/"${DIR}" "${BASEDIR}"/usr/ 2>/dev/null
-	done
-
-	pot start -p $BASENAME
-
-	for PKG in pkg64 pkg64c pkg64cb; do
-		echo Bootstrapping $PKG
-		pot exec -p $BASENAME $PKG bootstrap -fy && $PKG update -f
-	done
-
-	pot stop -p $BASENAME
 fi
 echo Installing flavours to $(realpath ${FLAVOURS})
 install -m 644 flavours/github-act flavours/github-act-configured ${FLAVOURS}
+install flavours/bootstrap ${FLAVOURS}
 install flavours/github-act ${FLAVOURS}
 install flavours/github-act.sh ${FLAVOURS}
 install flavours/github-act-configure.sh ${FLAVOURS}

--- a/install.sh
+++ b/install.sh
@@ -33,5 +33,3 @@ install gh_actions /usr/local64/etc/rc.d/
 install jobs/scrub-pool.sh /etc/cron.d/scrub-pool.sh
 install jobs/clean-pots.sh /etc/cron.d/clean-pots.sh
 install jobs/restart-actions.sh /etc/cron.d/restart-actions.sh
-cat jobs/tabs >> crontab
-sysrc cron_enable="YES"

--- a/install.sh
+++ b/install.sh
@@ -6,10 +6,20 @@ if [ ! -d ${FLAVOURS} ]; then
 	echo "Can't locate pot install"
 	exit 1
 fi
-DIR=
-BASEDIR="${POT_MOUNT_BASE}"bases/"${FREEBSD_VERSION}"
-echo Installing base ${FREEBSD_VERSION} pot to ${BASEDIR}
+
+BASENAME="base-"${FREEBSD_VERSION}
+BASEDIR="${POT_MOUNT_BASE}/bases/${BASENAME}/${FREEBSD_VERSION}"
+echo Creating base pot for ${FREEBSD_VERSION}
 if [ ! -e "${BASEDIR}" ]; then
+	mkdir -p /usr/local/share/freebsd/MANIFESTS/
+	ARCH=$(curl -s \
+		https://download.cheribsd.org/releases/arm64/aarch64c/ | \
+		grep -Eo "\w{1,}\.\w{1,}" | sort -u)
+	for RELEASE in $ARCH; do
+		curl -C - "https://download.cheribsd.org/releases/arm64/aarch64c/$RELEASE/ftp/MANIFEST" > \
+		/usr/local/share/freebsd/MANIFESTS/arm64-aarch64c-$RELEASE-RELEASE
+	done
+
 	pot create-base -r $FREEBSD_VERSION
 
 	echo Adding libraries to the $BASENAME pot

--- a/jobs/clean-pots.sh
+++ b/jobs/clean-pots.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 set -euo pipefail
 
 # Remove any misconfigured jails

--- a/jobs/restart-actions.sh
+++ b/jobs/restart-actions.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 set -euo pipefail
 
 # Restart the host's GitHub Actions service

--- a/jobs/scrub-pool.sh
+++ b/jobs/scrub-pool.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 set -euo pipefail
 
 # Perform consistency checks on ZFS pools

--- a/jobs/tabs
+++ b/jobs/tabs
@@ -1,4 +1,0 @@
-* 9 */1 * * /sbin/zpool status -v
-* 12 */1 * * /etc/cron.d/scrub-pool.sh
-* */1 * * * /etc/cron.d/clean-pots.sh
-*/1 * * * * /etc/cron.d/restart-actions.sh


### PR DESCRIPTION
This patch will fix the bootstrapping of pkg64, pkg64c, and pk64cb by ephemeral CheriBSD jails, specifically through the creation of a sibling 'pot' to provide a local copy of the root `/usr` libraries. That sibling is then cloned by all subsequent ephemeral jails, via `pot snap` and `pot clone`, and those pots then install and execute an unofficial Go version of GitHub's tooling for self-hosted runners.