### PR TITLE
Revert the creation of base pots via install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It makes certain assumptions, that `GODEBUG="asyncpreemptoff=1"` is
 necessary to prevent kernel panics, owing to a known bug affecting the
 Go runtime on CheriBSD.
 It also copies the libraries for CheriBSD's various ABIs from the host
-to the release's base pot to ensure that `pkg64` and `pkg64cb` are
+to a sibling pot, later cloned, to ensure that `pkg64` and `pkg64cb` are
 useable on capability-aware systems like Morello.
 To install under CheriBSD 23.11, for instance:
 ```shell

--- a/create-base.sh
+++ b/create-base.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eo pipefail
+if [ ! "${FREEBSD_VERSION}" ]; then
+    mkdir -p /usr/local/share/freebsd/MANIFESTS/
+    ARCH=$(curl -s \
+        https://download.cheribsd.org/releases/arm64/aarch64c/ | \
+        grep -Eo "\w{1,}\.\w{1,}" | sort -u)
+    for RELEASE in $ARCH; do
+        curl -C - "https://download.cheribsd.org/releases/arm64/aarch64c/$RELEASE/ftp/MANIFEST" > \
+        /usr/local/share/freebsd/MANIFESTS/arm64-aarch64c-$RELEASE-RELEASE
+    done
+    echo Finished downloading the most recent CheriBSD manifests
+
+    FREEBSD_VERSION=$(echo $ARCH | awk -F " " '{print $NF}')
+fi
+
+if [ ! $(pot ls -b | grep -o ${FREEBSD_VERSION}) ]; then
+    echo Creating base pot for $FREEBSD_VERSION
+
+    pot create-base -r $FREEBSD_VERSION
+else
+    echo Found an existing base pot for CheriBSD $FREEBSD_VERSION
+fi

--- a/install.sh
+++ b/install.sh
@@ -7,20 +7,6 @@ if [ ! -d ${FLAVOURS} ]; then
 	exit 1
 fi
 
-if [ ! $(pot ls -b | grep -Eo ${FREEBSD_VERSION}) ]; then
-	echo Creating base pot for ${FREEBSD_VERSION}
-	mkdir -p /usr/local/share/freebsd/MANIFESTS/
-	ARCH=$(curl -s \
-		https://download.cheribsd.org/releases/arm64/aarch64c/ | \
-		grep -Eo "\w{1,}\.\w{1,}" | sort -u)
-	for RELEASE in $ARCH; do
-		curl -C - "https://download.cheribsd.org/releases/arm64/aarch64c/$RELEASE/ftp/MANIFEST" > \
-		/usr/local/share/freebsd/MANIFESTS/arm64-aarch64c-$RELEASE-RELEASE
-	done
-
-	pot create-base -r $FREEBSD_VERSION
-
-fi
 echo Installing flavours to $(realpath ${FLAVOURS})
 install -m 644 flavours/github-act flavours/github-act-configured ${FLAVOURS}
 install flavours/bootstrap ${FLAVOURS}


### PR DESCRIPTION
This PR reverts the base pot creation process via `./install.sh`, to leave that instead to the user's discretion.