### PR TITLE
Generate random pot names and use CheriBSD versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ to a sibling pot, later cloned, to ensure that `pkg64` and `pkg64cb` are
 useable on capability-aware systems like Morello.
 To install under CheriBSD 23.11, for instance:
 ```shell
-POT_MOUNT_BASE=/opt/pot FREEBSD_VERSION=23.11 ./install.sh
+POT_MOUNT_BASE=/opt/pot CHERIBSD_BUILD_ID=23.11 ./install.sh
 ```
 
 To initialise a runner via GitHub:
 ```shell
 POT_MOUNT_BASE=/opt/pot/ \
-FREEBSD_VERSION=23.11 \
+CHERIBSD_BUILD_ID=23.11 \
 RUNNER_NAME=self-hosted \
 ./config.sh --url YOUR_REPOSITORY_URL --token YOUR_TOKEN
 ```
@@ -56,8 +56,8 @@ Paste that command into a root terminal in the directory where you have cloned t
 
 Three environment variables affect this command:
 
- - `FREEBSD_VERSION` specifies the version of FreeBSD to use (e.g. 13.1).
-   If not specified this is the version of your host system.
+ - `CHERIBSD_BUILD_ID` specifies the build of CheriBSD to use (e.g. 23.11).
+   If not specified this is the latest build of CheriBSD.
  - `RUNNER_NAME` specifies the name to give to this runner.
    If not specified then this is the {your hostname}-freebsd-{version number}.
  - `RUNNER_FLAVOURS` specifies a space-separated list of flavours that will be applied to the pot.

--- a/check-envs.sh
+++ b/check-envs.sh
@@ -2,13 +2,11 @@ if [ ! "${CHERIBSD_BUILD_ID}" ] ; then
 	ARCH=$(curl -s \
 	https://download.cheribsd.org/releases/arm64/aarch64c/ | \
 		grep -Eo "\w{1,}\.\w{1,}" | sort -u)
-	CHERIBSD_BUILD_ID=$(echo $ARCH | awk -F " " '{print $NF}')
+	CHERIBSD_BUILD_ID=$(echo ${ARCH} | awk -F " " '{print $NF}')
 	echo CHERIBSD_BUILD_ID not set, using ${CHERIBSD_BUILD_ID}
 fi
 if [ ! "${RUNNER_NAME}" ] ; then
-	HOST=$(. /etc/os-release; echo $NAME)
-	RANDOM=$(LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 8)
-	RUNNER_NAME=$HOST-$CHERIBSD_BUILD_ID-$RANDOM
+	RUNNER_NAME=CheriBSD-${CHERIBSD_BUILD_ID}-${RANDOM}
 	echo RUNNER_NAME not set, using ${RUNNER_NAME}
 fi
 if [ ! "${POT_MOUNT_BASE}" ] ; then

--- a/check-envs.sh
+++ b/check-envs.sh
@@ -1,9 +1,14 @@
-if [ ! "${FREEBSD_VERSION}" ] ; then
-	FREEBSD_VERSION=$(freebsd-version -u | sed -r 's/-.*//')
-	echo FREEBSD_VERSION not set, using ${FREEBSD_VERSION}
+if [ ! "${CHERIBSD_BUILD_ID}" ] ; then
+	ARCH=$(curl -s \
+	https://download.cheribsd.org/releases/arm64/aarch64c/ | \
+		grep -Eo "\w{1,}\.\w{1,}" | sort -u)
+	CHERIBSD_BUILD_ID=$(echo $ARCH | awk -F " " '{print $NF}')
+	echo CHERIBSD_BUILD_ID not set, using ${CHERIBSD_BUILD_ID}
 fi
 if [ ! "${RUNNER_NAME}" ] ; then
-	RUNNER_NAME=$(hostname)-freebsd-${FREEBSD_VERSION}
+	HOST=$(. /etc/os-release; echo $NAME)
+	RANDOM=$(LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 8)
+	RUNNER_NAME=$HOST-$CHERIBSD_BUILD_ID-$RANDOM
 	echo RUNNER_NAME not set, using ${RUNNER_NAME}
 fi
 if [ ! "${POT_MOUNT_BASE}" ] ; then

--- a/config.sh
+++ b/config.sh
@@ -8,6 +8,8 @@ if [ "$1" != '--url' -o "$3" != '--token' ] ; then
 	exit 1
 fi
 
+# Generate a random string for the runner name, if using config.sh without variables
+export RANDOM=$(LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 8)
 . ${SCRIPTDIR}/check-envs.sh
 
 mkdir -p ${RUNNER_CONFIG_DIRECTORY}

--- a/config.sh
+++ b/config.sh
@@ -25,7 +25,7 @@ echo "GITHUB_TOKEN=$4" >> github.conf
 echo "RUNNER_NAME=${RUNNER_NAME}" >> github.conf
 
 echo "RUNNER_FLAVOURS=${RUNNER_FLAVOURS}" > act-config.sh
-echo "FREEBSD_VERSION=${FREEBSD_VERSION}" >> act-config.sh
+echo "CHERIBSD_BUILD_ID=${CHERIBSD_BUILD_ID}" >> act-config.sh
 echo "RUNNER_NAME=${RUNNER_NAME}" >> act-config.sh
 echo "POTNAME=${POTNAME}" >> act-config.sh
 

--- a/create-base.sh
+++ b/create-base.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eo pipefail
-if [ ! "${FREEBSD_VERSION}" ]; then
+if [ ! "${CHERIBSD_BUILD_ID}" ]; then
     mkdir -p /usr/local/share/freebsd/MANIFESTS/
     ARCH=$(curl -s \
         https://download.cheribsd.org/releases/arm64/aarch64c/ | \
@@ -11,13 +11,13 @@ if [ ! "${FREEBSD_VERSION}" ]; then
     done
     echo Finished downloading the most recent CheriBSD manifests
 
-    FREEBSD_VERSION=$(echo $ARCH | awk -F " " '{print $NF}')
+    CHERIBSD_BUILD_ID=$(echo $ARCH | awk -F " " '{print $NF}')
 fi
 
-if [ ! $(pot ls -b | grep -o ${FREEBSD_VERSION}) ]; then
-    echo Creating base pot for $FREEBSD_VERSION
+if [ ! $(pot ls -b | grep -o ${CHERIBSD_BUILD_ID}) ]; then
+    echo Creating base pot for $CHERIBSD_BUILD_ID
 
-    pot create-base -r $FREEBSD_VERSION
+    pot create-base -r $CHERIBSD_BUILD_ID
 else
-    echo Found an existing base pot for CheriBSD $FREEBSD_VERSION
+    echo Found an existing base pot for CheriBSD $CHERIBSD_BUILD_ID
 fi

--- a/create-runner.sh
+++ b/create-runner.sh
@@ -37,7 +37,7 @@ else
 fi
 
 if [ ! -d $SIBLING_DIR ]; then
-    pot create -p sibling -b ${FREEBSD_VERSION} -t single -f bootstrap
+    pot create -p sibling -b ${CHERIBSD_BUILD_ID} -t single -f bootstrap
     pot snap -p sibling
 fi
 

--- a/flavours/github-act-configure.sh
+++ b/flavours/github-act-configure.sh
@@ -23,7 +23,7 @@ GODEBUG="asyncpreemptoff=1" /usr/local64/bin/github-act-runner configure \
     --url "https://github.com/${GITHUB_ORG}" \
     --token "${GITHUB_TOKEN}" \
     --name "${POTNAME}" \
-    --labels cheribsd,"cheribsd-${FREEBSD_VERSION}",freebsd,"freebsd-${VERSION}" \
+    --labels cheribsd,"cheribsd-${CHERIBSD_BUILD_ID}",freebsd,"freebsd-${VERSION}" \
     --unattended
 
 echo "GitHub Actions runner configured for ${POTNAME}"

--- a/flavours/github-act-configure.sh
+++ b/flavours/github-act-configure.sh
@@ -18,12 +18,11 @@ GITHUB_TOKEN=$(cat "$TOKEN_FILE")
 
 # Configure the runner
 cd /root/runner
-VERSION=$(freebsd-version -u | sed -r 's/-.*//')
 GODEBUG="asyncpreemptoff=1" /usr/local64/bin/github-act-runner configure \
     --url "https://github.com/${GITHUB_ORG}" \
     --token "${GITHUB_TOKEN}" \
     --name "${POTNAME}" \
-    --labels cheribsd,"cheribsd-${CHERIBSD_BUILD_ID}",freebsd,"freebsd-${VERSION}" \
+    --labels cheribsd,"cheribsd-${CHERIBSD_BUILD_ID}" \
     --unattended
 
 echo "GitHub Actions runner configured for ${POTNAME}"

--- a/recreate-all-runners.sh
+++ b/recreate-all-runners.sh
@@ -3,13 +3,13 @@
 for I in `pwd`/runners/*/act-config.sh ; do
 	if [ -f "$I" ] ; then
 		RUNNER_FLAVOURS=
-		FREEBSD_VERSION=
+		CHERIBSD_BUILD_ID=
 		RUNNER_NAME=
 		POTNAME=
 		. $I
 		echo Recreating ${RUNNER_NAME}
 		export RUNNER_FLAVOURS
-		export FREEBSD_VERSION
+		export CHERIBSD_BUILD_ID
 		export RUNNER_NAME
 		export POTNAME
 		./recreate-runner.sh


### PR DESCRIPTION
Locating a suitable version number can be challenging as `uname` and `/etc/os-release` on CheriBSD both point to the semantic versions of FreeBSD, e.g. '14.0', while CTSRD uses date-based versioning for the fork: [download.cheribsd.org](https://download.cheribsd.org/releases/arm64/aarch64c/).