### PR TITLE
Move the package installation upstream

### DIFF
--- a/create-runner.sh
+++ b/create-runner.sh
@@ -38,6 +38,13 @@ fi
 
 if [ ! -d $SIBLING_DIR ]; then
     pot create -p sibling -b ${CHERIBSD_BUILD_ID} -t single -f bootstrap
+    pot start -p sibling
+    pot exec -p sibling cp -R /root/lib64 /usr
+    pot exec -p sibling cp -R /root/lib64cb /usr
+    pot exec -p sibling rm -rdf /root/lib64
+    pot exec -p sibling rm -rdf /root/lib64cb
+    pot exec -p sibling pkg64 install -y bash curl git node readline
+    pot stop -p sibling
     pot snap -p sibling
 fi
 

--- a/flavours/github-act
+++ b/flavours/github-act
@@ -1,6 +1,3 @@
 copy-in -s github.conf -d /root/github-config
 set-attribute -A persistent -V NO
 set-attribute -A no-rc-script -V ON
-set-attribute -A no-tmpfs -V ON
-set-attribute -A nullfs -V ON
-set-attribute -A zfs -V ON

--- a/flavours/github-act-configure.sh
+++ b/flavours/github-act-configure.sh
@@ -16,6 +16,9 @@ if [ ! -f "$TOKEN_FILE" ]; then
 fi
 GITHUB_TOKEN=$(cat "$TOKEN_FILE")
 
+ARCH=$(ls /usr/local/share/freebsd/MANIFESTS | \
+    grep -Eo "\w{1,}\.\w{1,}" | sort -u)
+CHERIBSD_BUILD_ID=$(echo ${ARCH} | awk -F " " '{print $NF}')
 # Configure the runner
 cd /root/runner
 GODEBUG="asyncpreemptoff=1" /usr/local64/bin/github-act-runner configure \

--- a/flavours/github-act-copyout-config
+++ b/flavours/github-act-copyout-config
@@ -2,6 +2,3 @@ copy-in -s github.conf -d /root/github-config
 mount-in ${RUNNER_CONFIG_DIRECTORY}
 set-attribute -A persistent -V NO
 set-attribute -A no-rc-script -V ON
-set-attribute -A no-tmpfs -V ON
-set-attribute -A nullfs -V ON
-set-attribute -A zfs -V ON

--- a/flavours/github-act.sh
+++ b/flavours/github-act.sh
@@ -11,22 +11,7 @@ case $( . /etc/os-release; echo $NAME ) in
     ;;
 esac
 
-# Install dependencies
-cp -fR /root/lib64 /usr
-cp -fR /root/lib64cb /usr
-rm -R /root/lib64
-rm -R /root/lib64cb
-
-if [ $(which pkg64c) ]; then
-    for pkg in pkg64 pkg64c pkg64cb; do
-        $pkg -N || $pkg bootstrap -fy
-    done
-else
-    echo "[err] failed to find pkg64c"
-    exit
-fi
-
-pkg64 install -fy git node bash
+pkg64 install -y git node bash
 
 # Define the repository
 REPO_OWNER="ChristopherHX"


### PR DESCRIPTION
As part of the work to export pots that contain build utilities, this PR ensures that the upstream pot has essential components and is useable.