### PR TITLE
Repair runner attributes, names, and labels

### DIFF
--- a/flavours/github-act
+++ b/flavours/github-act
@@ -1,3 +1,4 @@
 copy-in -s github.conf -d /root/github-config
 set-attribute -A persistent -V NO
 set-attribute -A no-rc-script -V ON
+set-attribute -A no-tmpfs -V ON

--- a/flavours/github-act-configure.sh
+++ b/flavours/github-act-configure.sh
@@ -8,7 +8,8 @@ if [ -f "$CONFIG_FILE" ]; then
     cat "$CONFIG_FILE"
 fi
 
-ARCH=$(ls /usr/local/share/freebsd/MANIFESTS | \
+ARCH=$(curl -s \
+    https://download.cheribsd.org/releases/arm64/aarch64c/ | \
     grep -Eo "\w{1,}\.\w{1,}" | sort -u)
 CHERIBSD_BUILD_ID=$(echo ${ARCH} | awk -F " " '{print $NF}')
 # Configure the runner
@@ -16,8 +17,8 @@ cd /root/runner
 GODEBUG="asyncpreemptoff=1" /usr/local64/bin/github-act-runner configure \
     --url "${GITHUB_URL}" \
     --token "${GITHUB_TOKEN}" \
-    --name "${POTNAME}" \
+    --name "${RUNNER_NAME}" \
     --labels cheribsd,"cheribsd-${CHERIBSD_BUILD_ID}" \
     --unattended
 
-echo "GitHub Actions runner configured for ${POTNAME}"
+echo "GitHub Actions runner configured for ${RUNNER_NAME}"


### PR DESCRIPTION
This PR addresses several oversights:
1. Disabling TMPFS in github-act resolves a jexec failure due to a missing file (`/root/ci.sh`)
2. github-act-configure.sh expects `$RUNNER_NAME`, not `$POTNAME`
3. Manifests should be downloaded via a remote endpoint, such as [download.cheribsd.org](https://download.cheribsd.org)