### PR TITLE
Patch job to exclude ephemeral pots

### DIFF
--- a/jobs/restart-actions.sh
+++ b/jobs/restart-actions.sh
@@ -3,7 +3,7 @@
 # Where necessary, clear the old set of runners and replace them
 
 old_set=$(sysrc -n -q gh_actions_pots)
-new_set=$(pot ls -p -q | grep -i "cheribsd")
+new_set=$(pot ls -p -q | grep -i "cheribsd" | grep -v "-ephemeral")
 if [ ! "$(echo $old_set)" == "$(echo $new_set)" ]; then
     echo "Adding new runners to rc.conf:" $new_set
     sysrc -q -x gh_actions_pots


### PR DESCRIPTION
If restart-actions.sh executes while one of the ephemeral jails is currently in flight, then it will be added to the "gh_actions_pots" variable in rc.conf. This also impacts the scripts' ability to destroy the pots as intended and makes the clean-up process generally difficult to automate safely. To avoid this path entirely, we should just exclude the string.