### PR TITLE
Use pot-copy-out in config.sh

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -39,4 +39,4 @@ RUNNER_FLAVOURS="github-act-configure ${RUNNER_FLAVOURS}"
 . ${SCRIPTDIR}/create-runner.sh
 
 # Copy the configuration out of the jail.
-pot copy-out -p "${POTNAME}" -s "/root/runner/*" -d "${RUNNER_CONFIG_DIRECTORY}"
+pot copy-out -p "${POTNAME}" -s "/root/runner/settings.json" -d "${RUNNER_CONFIG_DIRECTORY}"

--- a/config.sh
+++ b/config.sh
@@ -37,4 +37,4 @@ RUNNER_FLAVOURS="github-act-configure ${RUNNER_FLAVOURS}"
 . ${SCRIPTDIR}/create-runner.sh
 
 # Copy the configuration out of the jail.
-pot-copy-out -p "${POTNAME}" -s "/root/runner/*" -d "${RUNNER_CONFIG_DIRECTORY}"
+pot copy-out -p "${POTNAME}" -s "/root/runner/*" -d "${RUNNER_CONFIG_DIRECTORY}"

--- a/config.sh
+++ b/config.sh
@@ -37,6 +37,4 @@ RUNNER_FLAVOURS="github-act-configure ${RUNNER_FLAVOURS}"
 . ${SCRIPTDIR}/create-runner.sh
 
 # Copy the configuration out of the jail.
-# FIXME: pot does not provide any mechanism for doing this that doesn't involve
-# poking at its internals.  If one is added then we should use it.
-cp ${POT_MOUNT_BASE}/jails/${POTNAME}/m/root/runner/* ${RUNNER_CONFIG_DIRECTORY}
+pot-copy-out -p "${POTNAME}" -s "/root/runner/*" -d "${RUNNER_CONFIG_DIRECTORY}"


### PR DESCRIPTION
Replace the FIXME with use of `pot-copy-out` instead of `cp` https://github.com/bsdpot/pot/blob/9ac5a5fc15843039e1c266cbe9b083f95dd33952/share/pot/copy-out.sh#L49