### PR TITLE
sanitise user input

### DIFF
--- a/check-envs.sh
+++ b/check-envs.sh
@@ -14,8 +14,8 @@ if [ ! "${POT_MOUNT_BASE}" ] ; then
 	echo POT_MOUNT_BASE not set, using ${POT_MOUNT_BASE}
 fi
 CHERIBSD_BUILD_ID=$(echo ${CHERIBSD_BUILD_ID} | sed 's/\s/_/g')
-RUNNER_NAME=$(echo ${RUNNER_NAME} | sed 's/\s/_/g;s/[$*?]//g')
-POT_MOUNT_BASE=$(echo ${POT_MOUNT_BASE} | sed 's/\s/_/g;s/[$*?]//g')
+RUNNER_NAME=$(echo ${RUNNER_NAME} | sed 's/\s/_/g; s/[$*?]//g')
+POT_MOUNT_BASE=$(echo ${POT_MOUNT_BASE} | sed 's/\s/_/g; s/[$*?]//g')
 # Set the pot name to use underscores in place of dots (the one character pot
 # names are apparently not allowed).
 POTNAME=$(echo ${RUNNER_NAME} | sed 's/\./_/g')

--- a/check-envs.sh
+++ b/check-envs.sh
@@ -13,11 +13,9 @@ if [ ! "${POT_MOUNT_BASE}" ] ; then
 	POT_MOUNT_BASE=/opt/pot
 	echo POT_MOUNT_BASE not set, using ${POT_MOUNT_BASE}
 fi
-CHERIBSD_BUILD_ID=$(echo ${CHERIBSD_BUILD_ID} | sed 's/ /_/g')
-RUNNER_NAME=$(echo ${RUNNER_NAME} | sed 's/ /_/g')
-RUNNER_NAME=$(echo ${RUNNER_NAME} | sed 's/[$*?]//g')
-POT_MOUNT_BASE=$(echo ${POT_MOUNT_BASE} | sed 's/ /_/g')
-POT_MOUNT_BASE=$(echo ${POT_MOUNT_BASE} | sed 's/[$*?]//g')
+CHERIBSD_BUILD_ID=$(echo ${CHERIBSD_BUILD_ID} | sed 's/\s/_/g')
+RUNNER_NAME=$(echo ${RUNNER_NAME} | sed 's/\s/_/g;s/[$*?]//g')
+POT_MOUNT_BASE=$(echo ${POT_MOUNT_BASE} | sed 's/\s/_/g;s/[$*?]//g')
 # Set the pot name to use underscores in place of dots (the one character pot
 # names are apparently not allowed).
 POTNAME=$(echo ${RUNNER_NAME} | sed 's/\./_/g')

--- a/check-envs.sh
+++ b/check-envs.sh
@@ -13,9 +13,12 @@ if [ ! "${POT_MOUNT_BASE}" ] ; then
 	POT_MOUNT_BASE=/opt/pot
 	echo POT_MOUNT_BASE not set, using ${POT_MOUNT_BASE}
 fi
+CHERIBSD_BUILD_ID=$(echo ${CHERIBSD_BUILD_ID} | sed 's/ /_/g')
+RUNNER_NAME=$(echo ${RUNNER_NAME} | sed 's/ /_/g')
+RUNNER_NAME=$(echo ${RUNNER_NAME} | sed 's/[$*?]//g')
+POT_MOUNT_BASE=$(echo ${POT_MOUNT_BASE} | sed 's/ /_/g')
+POT_MOUNT_BASE=$(echo ${POT_MOUNT_BASE} | sed 's/[$*?]//g')
 # Set the pot name to use underscores in place of dots (the one character pot
 # names are apparently not allowed).
-# FIXME: We shouldn't be allowing anything that isn't allowed in a path
-# component here either.
 POTNAME=$(echo ${RUNNER_NAME} | sed 's/\./_/g')
 RUNNER_CONFIG_DIRECTORY=`pwd`/runners/${POTNAME}


### PR DESCRIPTION
fixes DRL-102

AFAIK the only character not allowed in filenames is NUL (which can't be stored in a variable anyways, so does not have to be checked for).

These 3 env vars are used by other scripts however. This PR ensures that all whitespace characters are converted to _ and special characters $*? are stripped.