### PR TITLE
Add LLVM to the upstream jail

### DIFF
--- a/create-runner.sh
+++ b/create-runner.sh
@@ -25,7 +25,7 @@ if [ ! -d $SIBLING_DIR ]; then
     pot exec -p sibling cp -R /root/lib64cb /usr
     pot exec -p sibling rm -rdf /root/lib64
     pot exec -p sibling rm -rdf /root/lib64cb
-    pot exec -p sibling pkg64 install -y bash curl git node readline
+    pot exec -p sibling pkg64 install -y bash curl git llvm-base node readline
     pot stop -p sibling
     pot snap -p sibling
 fi


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Feature

## High level description

This change adds the LLVM package to the upstream jail, to reduce the time taken for a workflow to finish. 

## Describe alternatives you've considered

GitHub caching might be an option, but adding packages directly to a jail is more in keeping with the design of Pot itself and its objective of offering containerisation within FreeBSD. A cache couldn't be exported along with the jail, when running `pot export`, hence the build artefact wouldn't be an accurate recreation of the original state. As a result, installing packages with a view to exporting the jail as a tarball is still the preferred approach.